### PR TITLE
Removing NPM postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   },
   "scripts": {
     "test": "tap test/test-*.js",
-    "browserify": "browserify -r ./index.js:js-2dmath -o js-2dmath-browser.js",
-    "postinstall": "grunt dist"
+    "browserify": "browserify -r ./index.js:js-2dmath -o js-2dmath-browser.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'd like to use this module via NPM, but install fails as the `postinstall` script tries to run `grunt`, which is not specified in the package dependencies.

When using the module via NPM, you usually don't need a browser build. So I would rather not add grunt to the dependencies, but just remove the `postinstall` script.

Thanks for this lib, looking forward to giving it a try!
